### PR TITLE
Update 2016-03-11-webforpentester-dir-traversal.markdown

### DIFF
--- a/source/_posts/2016-03-11-webforpentester-dir-traversal.markdown
+++ b/source/_posts/2016-03-11-webforpentester-dir-traversal.markdown
@@ -96,12 +96,11 @@ if (!is_file($path))
 	die();
 	...
 ```
-The developer tried to filter the file var. However, I can still use Null character to bypass it.
-The web application will check the path extension and verify that it is a .png file, bypassing the filter. When this path is passed to the filesystem, the null byte character effectively tells the filesystem to ignore anything that comes after it. When the path is resolved by the filesystem, it interprets the directory traversal vulns and transforms ‘/var/www/images/../../../etc/passwd%00new.png’ into ‘/etc/passwd’. 
+ The server-side code adds its own suffix (.png) to your payload. This can be easily bypassed, by using a NULL BYTE (which you need to URL-encode as %00). Using NULL BYTE to get rid of any suffix added by the server-side code is a common bypass. When this path is passed to the filesystem, the null byte character effectively tells the filesystem to ignore anything that comes after it. When the path is resolved by the filesystem, it interprets the directory traversal vulns and transforms ‘/var/www/files/../../../etc/passwd%00’ into ‘/etc/passwd’. 
 
 manual exploit:
 
-`http://192.168.79.162/dirtrav/example3.php?file=../../../../etc/passwd%00.png`
+`http://192.168.79.162/dirtrav/example3.php?file=../../../../etc/passwd%00`
 
 ####reference
 [Directory Traversal](https://www.fishnetsecurity.com/6labs/blog/common-web-application-vulnerabilities-part-6) 


### PR DESCRIPTION
The code does not check the extension but adds a (.png) extension, which can be bypassed by putting a null byte (%00) before the extension.